### PR TITLE
Update prod_client.py to take options

### DIFF
--- a/predict_client/prod_client.py
+++ b/predict_client/prod_client.py
@@ -8,13 +8,14 @@ from predict_client.util import predict_response_to_dict, make_tensor_proto
 
 
 class ProdClient:
-    def __init__(self, host, model_name, model_version):
+    def __init__(self, host, model_name, model_version, options=None):
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.host = host
         self.model_name = model_name
         self.model_version = model_version
+        self.options = options
 
     def predict(self, request_data, request_timeout=10):
 
@@ -25,7 +26,7 @@ class ProdClient:
 
         # Create gRPC client and request
         t = time.time()
-        channel = grpc.insecure_channel(self.host)
+        channel = grpc.insecure_channel(self.host, options=self.options)
         self.logger.debug('Establishing insecure channel took: {}'.format(time.time() - t))
 
         t = time.time()


### PR DESCRIPTION
I was running into an issue with gRPC size being only 4MB. This PR allows users to add options to their connection.

```python
client = ProdClient('localhost:8500', 'bse', 0, options=[
    ('grpc.max_send_message_length', 68108864), 
    ('grpc.max_receive_message_length', 68108864)])
```